### PR TITLE
Caching response after the download complete

### DIFF
--- a/CachingPlayerItem.swift
+++ b/CachingPlayerItem.swift
@@ -39,10 +39,15 @@ open class CachingPlayerItem: AVPlayerItem {
         var playingFromData = false
         var mimeType: String? // is required when playing from Data
         var session: URLSession?
+        let urlSessionConfiguration: URLSessionConfiguration
         var mediaData: Data?
         var response: URLResponse?
         var pendingRequests = Set<AVAssetResourceLoadingRequest>()
         weak var owner: CachingPlayerItem?
+        
+        init(urlSessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.default) {
+            self.urlSessionConfiguration = urlSessionConfiguration
+        }
         
         func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
             
@@ -68,9 +73,9 @@ open class CachingPlayerItem: AVPlayerItem {
         }
         
         func startDataRequest(with url: URL) {
-            let configuration = URLSessionConfiguration.default
-            configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
-            session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+            if session == nil {
+                session = URLSession(configuration: urlSessionConfiguration, delegate: self, delegateQueue: nil)
+            }
             session?.dataTask(with: url).resume()
         }
         
@@ -97,6 +102,12 @@ open class CachingPlayerItem: AVPlayerItem {
             if let errorUnwrapped = error {
                 owner?.delegate?.playerItem?(owner!, downloadingFailedWith: errorUnwrapped)
                 return
+            }
+            if let response = response,
+                let mediaData = mediaData,
+                let task = task as? URLSessionDataTask {
+                let cachedUrlResponse = CachedURLResponse(response: response, data: mediaData, userInfo: nil, storagePolicy: .allowed)
+                session.configuration.urlCache?.storeCachedResponse(cachedUrlResponse, for: task)
             }
             processPendingRequests()
             owner?.delegate?.playerItem?(owner!, didFinishDownloadingData: mediaData!)

--- a/CachingPlayerItem.swift
+++ b/CachingPlayerItem.swift
@@ -179,7 +179,7 @@ open class CachingPlayerItem: AVPlayerItem {
         
     }
     
-    fileprivate let resourceLoaderDelegate = ResourceLoaderDelegate()
+    fileprivate let resourceLoaderDelegate: ResourceLoaderDelegate
     fileprivate let url: URL
     fileprivate let initialScheme: String?
     fileprivate var customFileExtension: String?
@@ -195,13 +195,13 @@ open class CachingPlayerItem: AVPlayerItem {
     private let cachingPlayerItemScheme = "cachingPlayerItemScheme"
     
     /// Is used for playing remote files.
-    convenience init(url: URL) {
-        self.init(url: url, customFileExtension: nil)
+    convenience init(url: URL, urlSessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.default) {
+        self.init(url: url, customFileExtension: nil, urlSessionConfiguration: urlSessionConfiguration)
     }
     
     /// Override/append custom file extension to URL path.
     /// This is required for the player to work correctly with the intended file type.
-    init(url: URL, customFileExtension: String?) {
+    init(url: URL, customFileExtension: String?, urlSessionConfiguration: URLSessionConfiguration = URLSessionConfiguration.default) {
         
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
             let scheme = components.scheme,
@@ -217,6 +217,8 @@ open class CachingPlayerItem: AVPlayerItem {
             urlWithCustomScheme.appendPathExtension(ext)
             self.customFileExtension = ext
         }
+        
+        self.resourceLoaderDelegate = ResourceLoaderDelegate(urlSessionConfiguration: urlSessionConfiguration)
         
         let asset = AVURLAsset(url: urlWithCustomScheme)
         asset.resourceLoader.setDelegate(resourceLoaderDelegate, queue: DispatchQueue.main)
@@ -240,6 +242,7 @@ open class CachingPlayerItem: AVPlayerItem {
         self.url = fakeUrl
         self.initialScheme = nil
         
+        resourceLoaderDelegate = ResourceLoaderDelegate()
         resourceLoaderDelegate.mediaData = data
         resourceLoaderDelegate.playingFromData = true
         resourceLoaderDelegate.mimeType = mimeType


### PR DESCRIPTION
Hi,
First of all thanks for your library, is really useful and easy to use!
We have discovered that when using the URL initializer the response was never cached and the video was downloaded again each time.

This is probably caused by an Apple Bug referenced here: https://forums.developer.apple.com/thread/92119

This Bug says that URLCache, that is the object responsible for cache the URLSession responses, does not work with range requests that are the one used to reproduce videos.

We've modified your library so the response id cached manually after the download has completed, in this way for the URLCache it is a normal response and the next time the video is played it will not be downloaded again.
We had also modified the initializer so it is possible to provide a custom URLSessionConfiguration that is the object that contains the URLCache used, so it is possible to provide an URLCache with custom sizes for example.

Thank You!

Gruppio