### PR TITLE
Fix invalid expectedContentLength for streaming URLs.

### DIFF
--- a/CachingPlayerItem.swift
+++ b/CachingPlayerItem.swift
@@ -145,7 +145,10 @@ open class CachingPlayerItem: AVPlayerItem {
         func haveEnoughDataToFulfillRequest(_ dataRequest: AVAssetResourceLoadingDataRequest) -> Bool {
             
             let requestedOffset = Int(dataRequest.requestedOffset)
-            let requestedLength = dataRequest.requestedLength
+            let requestedLength: Int = {
+                guard let expectedContentLength = response?.expectedContentLength else { return dataRequest.requestedLength }
+                return Int(expectedContentLength)
+            }()
             let currentOffset = Int(dataRequest.currentOffset)
             
             guard let songDataUnwrapped = mediaData,


### PR DESCRIPTION
Get expectedContentLength from url’s response if any, otherwise will use the default implementation. Reference here: https://developer.apple.com/documentation/avfoundation/avassetresourceloadingdatarequest/1387720-requestedlength